### PR TITLE
Remove Skills Section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,6 @@ I am a data-driven problem solver with experience in banking operations, ERP sys
 - **[BRAC Bank (Bangladesh)](https://www.bracbank.com/)** | Officer, Operations *(Dec 2018 – Nov 2021)*  
 - **[Labaid (Bangladesh)](https://labaid.com.bd/)** | System Analyst *(Jan 2017 – Dec 2018)*  
 
-## 💡 Skills & Expertise
-- **Programming & Scripting**: Python, R, SQL  
-- **Databases**: MySQL, SQLite  
-- **Data Visualization**: Matplotlib, Seaborn, Excel, Jupyter Notebook, PowerBI  
-- **Data Preprocessing and Analysis**: Data Cleaning, Feature Engineering, Exploratory Data Analysis, Data Mining, Statistical Analysis  
-- **Machine Learning**: Supervised Learning (Regression, Classification), Unsupervised Learning (Clustering, Dimensionality Reduction), Model Evaluation and Validation
-- **Web Development**: Web2py, HTML, CSS  
-
 ## 📫 Connect with Me
 📧 **Email**: istiak.mahbub@outlook.com  
 🔗 **LinkedIn**: [istiak-mahbub](https://www.linkedin.com/in/istiak-mahbub/)  


### PR DESCRIPTION
## Summary
- drop the **Skills & Expertise** section from README

## Testing
- `pytest -q`
- `npm test --silent`
- `cargo test --quiet` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_684a008c993083208736352d1f65de44